### PR TITLE
Add an option to control whether to auto merge the prevState when reducing.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{*.json,*.yml, *.js}]
+[{*.json,*.yml,*.js}]
 indent_style = space
 indent_size = 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /dist
 npm-debug.log
+.idea

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,18 @@
-export default function reduceReducers(...reducers) {
+const defaultOptions = {
+  keepPrevState: true
+};
+
+export default function reduceReducers() {
+  let args = [...arguments],
+      options = defaultOptions;
+
+  if (typeof args[args.length - 1] !== 'function') {
+    options = Object.assign({}, options, args.pop());
+  }
+
   return (prevState, action) => {
-    let newState = reducers
+    let newState = args
       .reduce((state, reducer) => Object.assign({}, state, reducer(prevState, action)), {});
-    return Object.assign({}, prevState, newState);
+    return options.keepPrevState ? Object.assign({}, prevState, newState) : newState;
   }
 }

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -43,7 +43,7 @@ describe ('flatCombineReducers', () => {
     expect(reducer(undefined, { value: 3 })).to.deep.equal({ A: 6 });
   });
 
-  it('should keep the prevState when setting the option `keepPrevState` to true(default)', () => {
+  it('should keep the prevState when setting the option `mergePrevState` to true(default)', () => {
     const reducer = flatCombineReducers(
       (prevState, action) => ({A: prevState.A + action.value})
     );
@@ -51,10 +51,10 @@ describe ('flatCombineReducers', () => {
     expect(reducer({ A: 1, B: 2 }, { value: 3 })).to.deep.equal({ A: 4, B: 2 });
   });
 
-  it('should not keep the prevState when setting the option `keepPrevState` to false', () => {
+  it('should not keep the prevState when setting the option `mergePrevState` to false', () => {
     const reducer = flatCombineReducers(
       (prevState, action) => ({A: prevState.A + action.value}),
-      { keepPrevState: false }
+      { mergePrevState: false }
     );
 
     expect(reducer({ A: 1, B: 2 }, { value: 3 })).to.deep.equal({ A: 4 });

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -42,4 +42,21 @@ describe ('flatCombineReducers', () => {
 
     expect(reducer(undefined, { value: 3 })).to.deep.equal({ A: 6 });
   });
+
+  it('should keep the prevState when setting the option `keepPrevState` to true(default)', () => {
+    const reducer = flatCombineReducers(
+      (prevState, action) => ({A: prevState.A + action.value})
+    );
+
+    expect(reducer({ A: 1, B: 2 }, { value: 3 })).to.deep.equal({ A: 4, B: 2 });
+  });
+
+  it('should not keep the prevState when setting the option `keepPrevState` to false', () => {
+    const reducer = flatCombineReducers(
+      (prevState, action) => ({A: prevState.A + action.value}),
+      { keepPrevState: false }
+    );
+
+    expect(reducer({ A: 1, B: 2 }, { value: 3 })).to.deep.equal({ A: 4 });
+  });
 });


### PR DESCRIPTION
Comparing with the reducer logic in redux, the current logic will help us auto merge the newState into prevState. Which is good, but it may affect some current behaviors.
So I would suggest adding an option `mergePrevState` for the user to control whether or not use it.